### PR TITLE
Removes mention of datasets no longer used in package from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@ Calibration data for CVPIA's Structure Decision Making chinook life cycle models
 This package contains the following calibration datasets:
 
 * `calibration_year_index` and `calibration_year_spawn_index` the set of proxy years used to represent model inputs for 1997-2017 selected from the 1979-2000 simulation inputs.
-* `fall_run_calibration_params`, `spring_run_calibration_params`, `winter_run_calibration_params` cached model inputs for calibrating model for 1997-2017.
 * `grandtab_imputed` used as seeding values for calibration.
 * `grandtab_observed` used for comparison to predicted values in optimization process.
 
 and one function: 
 
-* `set_synth_years` generates model inputs for running the life cycle models in calibration mode
+* `set_synth_years` generates model inputs for running the life cycle models in calibration mode. For more information run `?set_synth_years` in the console. 
 
 See the `data-raw/` directory to see the process for creating the datasets listed above.
 


### PR DESCRIPTION
We no longer have `[ ]_run_calibration_params` as data objects so I removed these from the readme. Instead we use `set_synth_years(fallRunDSM::params)` to set calibration parameters within the calibration script. 